### PR TITLE
Updating out of date packages

### DIFF
--- a/bdr-master-master/scripts/postgres_94_bdr.sh
+++ b/bdr-master-master/scripts/postgres_94_bdr.sh
@@ -1,4 +1,4 @@
-set -e -u
+nstall -q -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpmset -e -u
 
 echo "Installing utils..."
 
@@ -8,7 +8,7 @@ yum install -y -q atool wget ping nano telnet
 
 echo "Installing postgres..."
 
-yum install -q -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm
+yum install -q -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
 yum install -q -y http://packages.2ndquadrant.com/postgresql-bdr94-2ndquadrant/yum-repo-rpms/postgresql-bdr94-2ndquadrant-redhat-1.0-2.noarch.rpm
 
 yum install -q -y postgresql-bdr94-bdr

--- a/bdr-master-master/scripts/postgres_94_bdr.sh
+++ b/bdr-master-master/scripts/postgres_94_bdr.sh
@@ -1,4 +1,4 @@
-nstall -q -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpmset -e -u
+set -e -u
 
 echo "Installing utils..."
 

--- a/hot-standby-master-slave/scripts/master.sh
+++ b/hot-standby-master-slave/scripts/master.sh
@@ -8,7 +8,7 @@ echo "exclude=mirror.smartmedia.net.id, kartolo.sby.datautama.net.id" >> /etc/yu
 
 yum install -y -q atool wget ping nano telnet
 
-yum localinstall -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm
+yum localinstall -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
 
 yum install -y postgresql94 postgresql94-contrib postgresql94-server
 

--- a/hot-standby-master-slave/scripts/slave.sh
+++ b/hot-standby-master-slave/scripts/slave.sh
@@ -8,7 +8,7 @@ echo "exclude=mirror.smartmedia.net.id, kartolo.sby.datautama.net.id" >> /etc/yu
 
 yum install -y -q atool wget ping nano telnet
 
-yum localinstall -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm
+yum localinstall -y http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
 
 yum install -y postgresql94 postgresql94-contrib postgresql94-server
 


### PR DESCRIPTION
The rpm file http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm no longer exists at that location and the build fails.
I have updated it to http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm which gets it working again.

Thanks